### PR TITLE
Move security policy from Docs to .github

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| R2   | :white_check_mark: |
+| R1   | :white_check_mark: |
+| R0   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+Please contact the SCS security team at security[at]scs[dot]community to ask security questions or report security issues. If you want to communicate with us encrypted, you can find our OpenPGP Key at https://scs.community/security.asc.


### PR DESCRIPTION
This PR moves our security policies from the Docs repository to the general .github repository in order to have a default security policy in all repositories: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file

Signed-off-by: Eduard Itrich <eduard@itrich.net>