### PR TITLE
point to the correct page for community and contribution

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -3,7 +3,7 @@
 # Sovereign Cloud Stack
 
 [Sovereign Cloud Stack (SCS)](https://scs.community/) is a network of existing and future providers of standardized sovereign cloud and container infrastructure to join forces in defining, implementing and operating a fully open, federated, compatible platform. By joining forces, the platform can support a healthy ecosystem for service and application developers and strengthen the digitalization efforts in Europe without creating large risks to lose control over the technology and the data.
-Good starting points are the [docs](https://github.com/SovereignCloudStack/Docs) repository and the '[How to contribute page](https://scs.community/contribute/)' page on the main website. The SCS Standards are in the standards repository and are easiest to navigate on the [Docs Website](https://docs.scs.community/).
+Good starting points are the [docs](https://github.com/SovereignCloudStack/Docs) repository and the '[How to contribute page](https://docs.scs.community/community)' page on the main website. The SCS Standards are in the standards repository and are easiest to navigate on the [Docs Website](https://docs.scs.community/).
 
 ## Follow us
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -3,7 +3,7 @@
 # Sovereign Cloud Stack
 
 [Sovereign Cloud Stack (SCS)](https://scs.community/) is a network of existing and future providers of standardized sovereign cloud and container infrastructure to join forces in defining, implementing and operating a fully open, federated, compatible platform. By joining forces, the platform can support a healthy ecosystem for service and application developers and strengthen the digitalization efforts in Europe without creating large risks to lose control over the technology and the data.
-Good starting points are the [docs](https://github.com/SovereignCloudStack/Docs) repository and the '[How to contribute page](https://docs.scs.community/community)' page on the main website. The SCS Standards are in the standards repository and are easiest to navigate on the [Docs Website](https://docs.scs.community/).
+Good starting points are the [docs](https://github.com/SovereignCloudStack/Docs) repository and the '[How to contribute page](https://docs.scs.community/community)' page on the docs website. The SCS Standards are in the standards repository and are easiest to navigate on the aforementioned [Docs Website](https://docs.scs.community/).
 
 ## Follow us
 


### PR DESCRIPTION
the old page (https://scs.community/contribute) was turned off. Noticed by @mitch000001